### PR TITLE
Generic functions

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -219,7 +219,7 @@ let rec gen_function funcs ?(linkage = Llvm.Linkage.Private)
       (* We both generate the code for extracting the closure and add the vars to the environment *)
       let temp_funcs =
         match kind with
-        | Simple | Anon -> funcs
+        | Simple -> funcs
         | Closure assoc ->
             let clsr_param = (Llvm.params func.value).(closure_index) in
             let clsr_type = typeof_aggregate assoc |> Llvm.pointer_type in
@@ -319,7 +319,6 @@ and gen_expr (vars : llvar Vars.t) typed_expr : llvar =
       let func =
         match abs.kind with
         | Simple -> func
-        | Anon -> failwith "Internal Error: Anonymous named function"
         | Closure assoc -> gen_closure_obj assoc func vars name
       in
       gen_expr (Vars.add name func vars) cont
@@ -330,8 +329,7 @@ and gen_expr (vars : llvar Vars.t) typed_expr : llvar =
       let name = lambda_name fun_get_state in
       let func = Vars.find name vars in
       match abs.kind with
-      | Simple -> failwith "Internal Error: Named anonymous function"
-      | Anon -> func
+      | Simple -> func
       | Closure assoc -> gen_closure_obj assoc func vars name)
   | App (callee, arg) -> gen_app vars callee arg
   | If (cond, e1, e2) -> gen_if vars cond e1 e2

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -20,3 +20,12 @@ let rec clean = function
   | TRecord (name, fields) ->
       TRecord (name, List.map (fun (name, typ) -> (name, clean typ)) fields)
   | t -> t
+
+let rec freeze = function
+  | TVar { contents = Unbound (str, _) } -> QVar str
+  | TVar { contents = Link t } -> freeze t
+  | TFun (params, ret, kind) -> TFun (List.map freeze params, freeze ret, kind)
+  | TRecord (name, fields) ->
+      let fields = List.map (fun (name, typ) -> (name, freeze typ)) fields in
+      TRecord (name, fields)
+  | t -> t

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -7,7 +7,7 @@ type typ =
   | TFun of typ list * typ * fun_kind
   | TRecord of string * (string * typ) list
 
-and fun_kind = Simple | Anon | Closure of (string * typ) list
+and fun_kind = Simple | Closure of (string * typ) list
 
 and tv = Unbound of string * int | Link of typ
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -13,7 +13,6 @@ and tv = Unbound of string * int | Link of typ
 
 let rec clean = function
   | TVar { contents = Link t } -> clean t
-  | QVar _ -> failwith "TODO think about this"
   | TFun (params, ret, Closure vals) ->
       let vals = List.map (fun (name, typ) -> (name, clean typ)) vals in
       TFun (List.map clean params, clean ret, Closure vals)

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -352,7 +352,7 @@ and typeof_function env loc name params body cont =
   (* this loc might not be correct *)
   (* typeof_let env loc name (Lambda (loc, param, body)) cont *)
   enter_level ();
-  let env, params_t = handle_params env loc params in
+
   (* Recursion allowed for named funcs *)
   let env =
     match snd name with
@@ -360,7 +360,8 @@ and typeof_function env loc name params body cont =
     | None -> Env.add_value (fst name) (newvar ()) env
     | Some t -> Env.add_value (fst name) (typeof_annot env loc t) env
   in
-  let bodytype = typeof env body in
+  let body_env, params_t = handle_params env loc params in
+  let bodytype = typeof body_env body in
   leave_level ();
   let funtype = TFun (params_t, bodytype, Simple) |> generalize in
   unify (loc, "") (Env.find (fst name) env) funtype;

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -346,7 +346,7 @@ and typeof_abs env loc params e =
   let type_e = typeof env e in
   leave_level ();
 
-  TFun (params_t, type_e, Anon) |> generalize
+  TFun (params_t, type_e, Simple) |> generalize
 
 and typeof_function env loc name params body cont =
   (* this loc might not be correct *)
@@ -535,7 +535,7 @@ and convert_lambda env loc params e =
   let env, closed_vars = Env.close_scope env in
   let kind =
     match List.filter_map (needs_capture env) closed_vars with
-    | [] -> Anon
+    | [] -> Simple
     | lst ->
         (* List.map fst lst |> String.concat ", " |> print_endline; *)
         Closure lst

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -606,6 +606,7 @@ and convert_function env loc { name; params; body; cont } =
 
 and convert_app env loc e1 args =
   let type_fun = convert env e1 in
+  (* let saved = freeze type_fun.typ in *)
   let typed_expr_args = List.map (convert env) args in
   let args_t = List.map (fun a -> a.typ) typed_expr_args in
   let res_t = newvar () in

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -670,16 +670,12 @@ and convert_function env loc { name; params; body; cont } =
 and convert_app env loc e1 args =
   let type_fun = convert env e1 in
   let generic = freeze type_fun.typ in
-  print_endline (string_of_type type_fun.typ);
-  (* TODO list.map2 here with generic params to figure out gen option *)
+
   let typed_exprs = List.map (convert env) args in
   let args_t = List.map (fun a -> a.typ) typed_exprs in
   let res_t = newvar () in
   unify (loc, "Application") type_fun.typ (TFun (args_t, res_t, Simple));
-  Printf.printf "%s\t%s\t%s\n"
-    (string_of_type type_fun.typ)
-    (string_of_type generic)
-    (string_of_type @@ TFun (args_t, res_t, Simple));
+
   (* Apply the 'result' of the unification the the typed_expr *)
   let apply typ texpr = { texpr with typ } in
   let targs = List.map2 apply args_t typed_exprs in

--- a/lib/typing.mli
+++ b/lib/typing.mli
@@ -4,15 +4,7 @@ exception Error of Ast.loc * string
 
 val string_of_type : typ -> string
 
-type abstraction = {
-  params : (string * typ) list;
-  body : typed_expr;
-  kind : fun_kind;
-}
-
-and const = Int of int | Bool of bool | Unit
-
-and expr =
+type expr =
   | Var of string
   | Const of const
   | Bop of Ast.bop * typed_expr * typed_expr
@@ -20,11 +12,19 @@ and expr =
   | Let of string * typed_expr * typed_expr
   | Lambda of abstraction
   | Function of string * int option * abstraction * typed_expr
-  | App of typed_expr * typed_expr list
+  | App of typed_expr * typed_expr list * (string * generic_fun) list
   | Record of (string * typed_expr) list
   | Field of (typed_expr * int)
 
 and typed_expr = { typ : typ; expr : expr }
+
+and const = Int of int | Bool of bool | Unit
+
+and fun_pieces = { tparams : typ list; ret : typ; kind : fun_kind }
+
+and abstraction = { nparams : string list; body : typed_expr; tp : fun_pieces }
+
+and generic_fun = { concrete : fun_pieces; generic : fun_pieces }
 
 type external_decl = string * typ
 

--- a/lib/typing.mli
+++ b/lib/typing.mli
@@ -12,7 +12,7 @@ type expr =
   | Let of string * typed_expr * typed_expr
   | Lambda of abstraction
   | Function of string * int option * abstraction * typed_expr
-  | App of typed_expr * typed_expr list * (string * generic_fun) list
+  | App of typed_expr * (typed_expr * (string * generic_fun) option) list
   | Record of (string * typed_expr) list
   | Field of (typed_expr * int)
 

--- a/test/functions.t/fib.smu
+++ b/test/functions.t/fib.smu
@@ -3,13 +3,6 @@ external printi : int -> unit
 function fib(n)
     if n < 2 then n
     else
-        -- local function
-        function fibn2(n)
-            fib(n - 2)
-        -- anonymous function
-        -- shadow fib. Since the function is anonymous, the inner fib call still calls the outer fib
-        fib = function (n)
-            fib(n - 1)
-        fibn2(n) + fib(n)
+        fib(n - 1) + fib(n - 2)
 
 printi(fib(30))

--- a/test/functions.t/generic_fun_arg.smu
+++ b/test/functions.t/generic_fun_arg.smu
@@ -1,5 +1,7 @@
 external printi : int -> unit
 
+type t = { x : int }
+
 -- This function is generic, i.e. only generated once
 -- and used for different functions
 function apply(x, f)
@@ -20,9 +22,12 @@ function makefalse(b)
   if b then false
   else b
 
--- Missing: Record
+-- simple t -> t
+function add1_rec(t)
+  { x = t.x + 3 }
 
 a = printi(apply(20, add1))
 a = printi(apply(20, add_closed))
+a = printi(apply({ x = 20 }, add1_rec).x)
 if apply(true, makefalse) then printi(1)
 else printi(0)

--- a/test/functions.t/generic_fun_arg.smu
+++ b/test/functions.t/generic_fun_arg.smu
@@ -1,0 +1,28 @@
+external printi : int -> unit
+
+-- This function is generic, i.e. only generated once
+-- and used for different functions
+function apply(x, f)
+  f(x)
+
+a = 2
+
+function add_closed(x)
+  -- we close over a
+  x + a
+
+-- simple int -> int
+function add1(x)
+  x + 1
+
+-- simple bool -> bool
+function makefalse(b)
+  if b then false
+  else b
+
+-- Missing: Record
+
+a = printi(apply(20, add1))
+a = printi(apply(20, add_closed))
+if apply(true, makefalse) then printi(1)
+else printi(0)

--- a/test/functions.t/run.t
+++ b/test/functions.t/run.t
@@ -115,8 +115,8 @@ We have downwards closures
     %clsr_capture_a = alloca { i32 }, align 8
     %a4 = bitcast { i32 }* %clsr_capture_a to i32*
     store i32 10, i32* %a4, align 4
-    %envptr = getelementptr inbounds %closure, %closure* %capture_a, i32 0, i32 1
     %env = bitcast { i32 }* %clsr_capture_a to i8*
+    %envptr = getelementptr inbounds %closure, %closure* %capture_a, i32 0, i32 1
     store i8* %env, i8** %envptr, align 8
     %funcptr5 = bitcast %closure* %capture_a to i8**
     %loadtmp = load i8*, i8** %funcptr5, align 8
@@ -131,37 +131,6 @@ We have downwards closures
 
 First class functions
   $ dune exec -- schmu first_class.smu | grep -v x86_64 && cc out.o stub.o && ./a.out
-  ; ModuleID = 'context'
-  source_filename = "context"
-  
-  %generic = type opaque
-  %closure = type { i8*, i8* }
-  
-  declare void @printi(i32 %0)
-  
-  define private i32 @__fun0(i32 %x) {
-  entry:
-    %addtmp = add i32 %x, 2
-    ret i32 %addtmp
-  }
-  
-  define void @__ig_ig(%generic* %0, %generic* %1, i8* %2, i64 %3, i64 %4) {
-  entry:
-    %5 = bitcast i8* %2 to %closure*
-    %funcptr = getelementptr inbounds %closure, %closure* %5, i32 0, i32 0
-    %loadtmp = load i8*, i8** %funcptr, align 8
-    %casttmp = bitcast i8* %loadtmp to i32 (i32)*
-    %6 = bitcast %generic* %1 to i32*
-    %7 = load i32, i32* %6, align 4
-    %8 = call i32 %casttmp(i32 %7)
-    %9 = bitcast %generic* %0 to i32*
-    store i32 %8, i32* %9, align 4
-    ret void
-  }
-  
-  declare i32 @add1(i32 %0)
-  
-  declare void @apply(%generic* %0, %generic* %1, %closure* %2, i64 %3, i64 %4)
   ; ModuleID = 'context'
   source_filename = "context"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
@@ -180,12 +149,14 @@ First class functions
   define void @__ig_ig(%generic* %0, %generic* %1, i8* %2, i64 %3, i64 %4) {
   entry:
     %5 = bitcast i8* %2 to %closure*
-    %funcptr1 = bitcast %closure* %5 to i8**
-    %loadtmp = load i8*, i8** %funcptr1, align 8
-    %casttmp = bitcast i8* %loadtmp to i32 (i32)*
     %6 = bitcast %generic* %1 to i32*
     %7 = load i32, i32* %6, align 4
-    %8 = call i32 %casttmp(i32 %7)
+    %funcptr2 = bitcast %closure* %5 to i8**
+    %loadtmp = load i8*, i8** %funcptr2, align 8
+    %casttmp = bitcast i8* %loadtmp to i32 (i32, i8*)*
+    %envptr = getelementptr inbounds %closure, %closure* %5, i32 0, i32 1
+    %loadtmp1 = load i8*, i8** %envptr, align 8
+    %8 = call i32 %casttmp(i32 %7, i8* %loadtmp1)
     %9 = bitcast %generic* %0 to i32*
     store i32 %8, i32* %9, align 4
     ret void
@@ -370,8 +341,8 @@ Captured values should not overwrite function params
     %clsr_two = alloca { i32 }, align 8
     %b4 = bitcast { i32 }* %clsr_two to i32*
     store i32 2, i32* %b4, align 4
-    %envptr = getelementptr inbounds %closure, %closure* %two, i32 0, i32 1
     %env = bitcast { i32 }* %clsr_two to i8*
+    %envptr = getelementptr inbounds %closure, %closure* %two, i32 0, i32 1
     store i8* %env, i8** %envptr, align 8
     %clstmp = alloca %closure, align 8
     %funptr15 = bitcast %closure* %clstmp to i8**

--- a/test/functions.t/run.t
+++ b/test/functions.t/run.t
@@ -4,7 +4,44 @@ Compile stubs
 Test name resolution and IR creation of functions
 We discard the triple, b/c it varies from distro to distro
 e.g. x86_64-unknown-linux-gnu on Fedora vs x86_64-pc-linux-gnu on gentoo
+
+Simple fibonacci
   $ dune exec -- schmu fib.smu | grep -v x86_64 && cc out.o stub.o && ./a.out
+  ; ModuleID = 'context'
+  source_filename = "context"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+  
+  declare void @printi(i32 %0)
+  
+  define private i32 @fib(i32 %n) {
+  entry:
+    %lesstmp = icmp slt i32 %n, 2
+    br i1 %lesstmp, label %ifcont, label %else
+  
+  else:                                             ; preds = %entry
+    %subtmp = sub i32 %n, 1
+    %0 = call i32 @fib(i32 %subtmp)
+    %subtmp1 = sub i32 %n, 2
+    %1 = call i32 @fib(i32 %subtmp1)
+    %addtmp = add i32 %0, %1
+    br label %ifcont
+  
+  ifcont:                                           ; preds = %entry, %else
+    %iftmp = phi i32 [ %addtmp, %else ], [ %n, %entry ]
+    ret i32 %iftmp
+  }
+  
+  define i32 @main(i32 %0) {
+  entry:
+    %1 = call i32 @fib(i32 30)
+    call void @printi(i32 %1)
+    ret i32 0
+  }
+  unit
+  832040
+
+Fibonacci, but we shadow a bunch
+  $ dune exec -- schmu shadowing.smu | grep -v x86_64 && cc out.o stub.o && ./a.out
   ; ModuleID = 'context'
   source_filename = "context"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/functions.t/run.t
+++ b/test/functions.t/run.t
@@ -421,6 +421,23 @@ Functions can be generic. In this test, we generate 'apply' only once and use it
     ret void
   }
   
+  define void @__tg_tg(%generic* %0, %generic* %1, i8* %2, i64 %3, i64 %4) {
+  entry:
+    %5 = bitcast i8* %2 to %closure*
+    %6 = bitcast %generic* %1 to { i32 }*
+    %funcptr2 = bitcast %closure* %5 to i8**
+    %loadtmp = load i8*, i8** %funcptr2, align 8
+    %casttmp = bitcast i8* %loadtmp to void ({ i32 }*, { i32 }*, i8*)*
+    %envptr = getelementptr inbounds %closure, %closure* %5, i32 0, i32 1
+    %loadtmp1 = load i8*, i8** %envptr, align 8
+    %ret = alloca { i32 }, align 8
+    call void %casttmp({ i32 }* %ret, { i32 }* %6, i8* %loadtmp1)
+    %7 = bitcast %generic* %0 to i8*
+    %8 = bitcast { i32 }* %ret to i8*
+    call void @llvm.memcpy.p0i8.p0i8.i64(i8* %7, i8* %8, i64 ptrtoint ({ i32 }* getelementptr ({ i32 }, { i32 }* null, i32 1) to i64), i1 false)
+    ret void
+  }
+  
   define void @__ig_ig(%generic* %0, %generic* %1, i8* %2, i64 %3, i64 %4) {
   entry:
     %5 = bitcast i8* %2 to %closure*
@@ -434,6 +451,20 @@ Functions can be generic. In this test, we generate 'apply' only once and use it
     %8 = call i32 %casttmp(i32 %7, i8* %loadtmp1)
     %9 = bitcast %generic* %0 to i32*
     store i32 %8, i32* %9, align 4
+    ret void
+  }
+  
+  define private void @add1_rec({ i32 }* %0, { i32 }* %t) {
+  entry:
+    %1 = alloca { i32 }, align 8
+    %x1 = bitcast { i32 }* %1 to i32*
+    %2 = bitcast { i32 }* %t to i32*
+    %3 = load i32, i32* %2, align 4
+    %addtmp = add i32 %3, 3
+    store i32 %addtmp, i32* %x1, align 4
+    %4 = bitcast { i32 }* %0 to i8*
+    %5 = bitcast { i32 }* %1 to i8*
+    call void @llvm.memcpy.p0i8.p0i8.i64(i8* %4, i8* %5, i64 ptrtoint ({ i32 }* getelementptr ({ i32 }, { i32 }* null, i32 1) to i64), i1 false)
     ret void
   }
   
@@ -486,11 +517,11 @@ Functions can be generic. In this test, we generate 'apply' only once and use it
   define i32 @main(i32 %0) {
   entry:
     %add_closed = alloca %closure, align 8
-    %funptr23 = bitcast %closure* %add_closed to i8**
-    store i8* bitcast (i32 (i32, i8*)* @add_closed to i8*), i8** %funptr23, align 8
+    %funptr31 = bitcast %closure* %add_closed to i8**
+    store i8* bitcast (i32 (i32, i8*)* @add_closed to i8*), i8** %funptr31, align 8
     %clsr_add_closed = alloca { i32 }, align 8
-    %a24 = bitcast { i32 }* %clsr_add_closed to i32*
-    store i32 2, i32* %a24, align 4
+    %a32 = bitcast { i32 }* %clsr_add_closed to i32*
+    store i32 2, i32* %a32, align 4
     %env = bitcast { i32 }* %clsr_add_closed to i8*
     %envptr = getelementptr inbounds %closure, %closure* %add_closed, i32 0, i32 1
     store i8* %env, i8** %envptr, align 8
@@ -498,12 +529,12 @@ Functions can be generic. In this test, we generate 'apply' only once and use it
     store i32 20, i32* %gen, align 4
     %1 = bitcast i32* %gen to %generic*
     %clstmp = alloca %closure, align 8
-    %funptr125 = bitcast %closure* %clstmp to i8**
-    store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__ig_ig to i8*), i8** %funptr125, align 8
+    %funptr133 = bitcast %closure* %clstmp to i8**
+    store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__ig_ig to i8*), i8** %funptr133, align 8
     %envptr2 = getelementptr inbounds %closure, %closure* %clstmp, i32 0, i32 1
     %wrapped = alloca %closure, align 8
-    %funptr326 = bitcast %closure* %wrapped to i8**
-    store i8* bitcast (i32 (i32)* @add1 to i8*), i8** %funptr326, align 8
+    %funptr334 = bitcast %closure* %wrapped to i8**
+    store i8* bitcast (i32 (i32)* @add1 to i8*), i8** %funptr334, align 8
     %envptr4 = getelementptr inbounds %closure, %closure* %wrapped, i32 0, i32 1
     store i8* null, i8** %envptr4, align 8
     %2 = bitcast %closure* %wrapped to i8*
@@ -518,8 +549,8 @@ Functions can be generic. In this test, we generate 'apply' only once and use it
     store i32 20, i32* %gen6, align 4
     %4 = bitcast i32* %gen6 to %generic*
     %clstmp7 = alloca %closure, align 8
-    %funptr827 = bitcast %closure* %clstmp7 to i8**
-    store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__ig_ig to i8*), i8** %funptr827, align 8
+    %funptr835 = bitcast %closure* %clstmp7 to i8**
+    store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__ig_ig to i8*), i8** %funptr835, align 8
     %envptr9 = getelementptr inbounds %closure, %closure* %clstmp7, i32 0, i32 1
     %5 = bitcast %closure* %add_closed to i8*
     store i8* %5, i8** %envptr9, align 8
@@ -529,26 +560,48 @@ Functions can be generic. In this test, we generate 'apply' only once and use it
     %6 = bitcast %generic* %ret11 to i32*
     %realret12 = load i32, i32* %6, align 4
     call void @printi(i32 %realret12)
-    %gen13 = alloca i1, align 1
-    store i1 true, i1* %gen13, align 1
-    %7 = bitcast i1* %gen13 to %generic*
-    %clstmp14 = alloca %closure, align 8
-    %funptr1528 = bitcast %closure* %clstmp14 to i8**
-    store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__bg_bg to i8*), i8** %funptr1528, align 8
-    %envptr16 = getelementptr inbounds %closure, %closure* %clstmp14, i32 0, i32 1
-    %wrapped17 = alloca %closure, align 8
-    %funptr1829 = bitcast %closure* %wrapped17 to i8**
-    store i8* bitcast (i1 (i1)* @makefalse to i8*), i8** %funptr1829, align 8
-    %envptr19 = getelementptr inbounds %closure, %closure* %wrapped17, i32 0, i32 1
-    store i8* null, i8** %envptr19, align 8
-    %8 = bitcast %closure* %wrapped17 to i8*
-    store i8* %8, i8** %envptr16, align 8
-    %ret20 = alloca i8, i64 ptrtoint (i1* getelementptr (i1, i1* null, i32 1) to i64), align 16
-    %ret21 = bitcast i8* %ret20 to %generic*
-    call void @apply(%generic* %ret21, %generic* %7, %closure* %clstmp14, i64 ptrtoint (i1* getelementptr (i1, i1* null, i32 1) to i64), i64 ptrtoint (i1* getelementptr (i1, i1* null, i32 1) to i64))
-    %9 = bitcast %generic* %ret21 to i1*
-    %realret22 = load i1, i1* %9, align 1
-    br i1 %realret22, label %then, label %else
+    %7 = alloca { i32 }, align 8
+    %x36 = bitcast { i32 }* %7 to i32*
+    store i32 20, i32* %x36, align 4
+    %8 = bitcast { i32 }* %7 to %generic*
+    %clstmp13 = alloca %closure, align 8
+    %funptr1437 = bitcast %closure* %clstmp13 to i8**
+    store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__tg_tg to i8*), i8** %funptr1437, align 8
+    %envptr15 = getelementptr inbounds %closure, %closure* %clstmp13, i32 0, i32 1
+    %wrapped16 = alloca %closure, align 8
+    %funptr1738 = bitcast %closure* %wrapped16 to i8**
+    store i8* bitcast (void ({ i32 }*, { i32 }*)* @add1_rec to i8*), i8** %funptr1738, align 8
+    %envptr18 = getelementptr inbounds %closure, %closure* %wrapped16, i32 0, i32 1
+    store i8* null, i8** %envptr18, align 8
+    %9 = bitcast %closure* %wrapped16 to i8*
+    store i8* %9, i8** %envptr15, align 8
+    %ret19 = alloca i8, i64 ptrtoint ({ i32 }* getelementptr ({ i32 }, { i32 }* null, i32 1) to i64), align 16
+    %ret20 = bitcast i8* %ret19 to %generic*
+    call void @apply(%generic* %ret20, %generic* %8, %closure* %clstmp13, i64 ptrtoint ({ i32 }* getelementptr ({ i32 }, { i32 }* null, i32 1) to i64), i64 ptrtoint ({ i32 }* getelementptr ({ i32 }, { i32 }* null, i32 1) to i64))
+    %10 = bitcast %generic* %ret20 to { i32 }*
+    %11 = bitcast { i32 }* %10 to i32*
+    %12 = load i32, i32* %11, align 4
+    call void @printi(i32 %12)
+    %gen21 = alloca i1, align 1
+    store i1 true, i1* %gen21, align 1
+    %13 = bitcast i1* %gen21 to %generic*
+    %clstmp22 = alloca %closure, align 8
+    %funptr2339 = bitcast %closure* %clstmp22 to i8**
+    store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__bg_bg to i8*), i8** %funptr2339, align 8
+    %envptr24 = getelementptr inbounds %closure, %closure* %clstmp22, i32 0, i32 1
+    %wrapped25 = alloca %closure, align 8
+    %funptr2640 = bitcast %closure* %wrapped25 to i8**
+    store i8* bitcast (i1 (i1)* @makefalse to i8*), i8** %funptr2640, align 8
+    %envptr27 = getelementptr inbounds %closure, %closure* %wrapped25, i32 0, i32 1
+    store i8* null, i8** %envptr27, align 8
+    %14 = bitcast %closure* %wrapped25 to i8*
+    store i8* %14, i8** %envptr24, align 8
+    %ret28 = alloca i8, i64 ptrtoint (i1* getelementptr (i1, i1* null, i32 1) to i64), align 16
+    %ret29 = bitcast i8* %ret28 to %generic*
+    call void @apply(%generic* %ret29, %generic* %13, %closure* %clstmp22, i64 ptrtoint (i1* getelementptr (i1, i1* null, i32 1) to i64), i64 ptrtoint (i1* getelementptr (i1, i1* null, i32 1) to i64))
+    %15 = bitcast %generic* %ret29 to i1*
+    %realret30 = load i1, i1* %15, align 1
+    br i1 %realret30, label %then, label %else
   
   then:                                             ; preds = %entry
     call void @printi(i32 1)
@@ -566,6 +619,7 @@ Functions can be generic. In this test, we generate 'apply' only once and use it
   unit
   21
   22
+  23
   0
 
 This is a regression test. The 'add1' function was not marked as a closure when being called from

--- a/test/functions.t/run.t
+++ b/test/functions.t/run.t
@@ -96,6 +96,8 @@ We have downwards closures
   source_filename = "context"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
   
+  %closure = type { i8*, i8* }
+  
   define private i32 @capture_a(i8* %0) {
   entry:
     %clsr = bitcast i8* %0 to { i32 }*
@@ -107,19 +109,19 @@ We have downwards closures
   
   define i32 @main(i32 %0) {
   entry:
-    %capture_a = alloca { i8*, i8* }, align 8
-    %funptr3 = bitcast { i8*, i8* }* %capture_a to i8**
+    %capture_a = alloca %closure, align 8
+    %funptr3 = bitcast %closure* %capture_a to i8**
     store i8* bitcast (i32 (i8*)* @capture_a to i8*), i8** %funptr3, align 8
     %clsr_capture_a = alloca { i32 }, align 8
     %a4 = bitcast { i32 }* %clsr_capture_a to i32*
     store i32 10, i32* %a4, align 4
-    %envptr = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %capture_a, i32 0, i32 1
+    %envptr = getelementptr inbounds %closure, %closure* %capture_a, i32 0, i32 1
     %env = bitcast { i32 }* %clsr_capture_a to i8*
     store i8* %env, i8** %envptr, align 8
-    %funcptr5 = bitcast { i8*, i8* }* %capture_a to i8**
+    %funcptr5 = bitcast %closure* %capture_a to i8**
     %loadtmp = load i8*, i8** %funcptr5, align 8
     %casttmp = bitcast i8* %loadtmp to i32 (i8*)*
-    %envptr1 = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %capture_a, i32 0, i32 1
+    %envptr1 = getelementptr inbounds %closure, %closure* %capture_a, i32 0, i32 1
     %loadtmp2 = load i8*, i8** %envptr1, align 8
     %1 = call i32 %casttmp(i8* %loadtmp2)
     ret i32 %1
@@ -133,6 +135,7 @@ First class functions
   source_filename = "context"
   
   %generic = type opaque
+  %closure = type { i8*, i8* }
   
   declare void @printi(i32 %0)
   
@@ -144,8 +147,8 @@ First class functions
   
   define void @__ig_ig(%generic* %0, %generic* %1, i8* %2, i64 %3, i64 %4) {
   entry:
-    %5 = bitcast i8* %2 to { i8*, i8* }*
-    %funcptr = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %5, i32 0, i32 0
+    %5 = bitcast i8* %2 to %closure*
+    %funcptr = getelementptr inbounds %closure, %closure* %5, i32 0, i32 0
     %loadtmp = load i8*, i8** %funcptr, align 8
     %casttmp = bitcast i8* %loadtmp to i32 (i32)*
     %6 = bitcast %generic* %1 to i32*
@@ -158,12 +161,13 @@ First class functions
   
   declare i32 @add1(i32 %0)
   
-  declare void @apply(%generic* %0, %generic* %1, { i8*, i8* }* %2, i64 %3, i64 %4)
+  declare void @apply(%generic* %0, %generic* %1, %closure* %2, i64 %3, i64 %4)
   ; ModuleID = 'context'
   source_filename = "context"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
   
   %generic = type opaque
+  %closure = type { i8*, i8* }
   
   declare void @printi(i32 %0)
   
@@ -175,8 +179,8 @@ First class functions
   
   define void @__ig_ig(%generic* %0, %generic* %1, i8* %2, i64 %3, i64 %4) {
   entry:
-    %5 = bitcast i8* %2 to { i8*, i8* }*
-    %funcptr1 = bitcast { i8*, i8* }* %5 to i8**
+    %5 = bitcast i8* %2 to %closure*
+    %funcptr1 = bitcast %closure* %5 to i8**
     %loadtmp = load i8*, i8** %funcptr1, align 8
     %casttmp = bitcast i8* %loadtmp to i32 (i32)*
     %6 = bitcast %generic* %1 to i32*
@@ -193,12 +197,12 @@ First class functions
     ret i32 %addtmp
   }
   
-  define private void @apply(%generic* %0, %generic* %x, { i8*, i8* }* %f, i64 %__3, i64 %__1) {
+  define private void @apply(%generic* %0, %generic* %x, %closure* %f, i64 %__3, i64 %__1) {
   entry:
-    %funcptr3 = bitcast { i8*, i8* }* %f to i8**
+    %funcptr3 = bitcast %closure* %f to i8**
     %loadtmp = load i8*, i8** %funcptr3, align 8
     %casttmp = bitcast i8* %loadtmp to void (%generic*, %generic*, i8*, i64, i64)*
-    %envptr = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %f, i32 0, i32 1
+    %envptr = getelementptr inbounds %closure, %closure* %f, i32 0, i32 1
     %loadtmp1 = load i8*, i8** %envptr, align 8
     %ret = alloca i8, i64 %__3, align 16
     %ret2 = bitcast i8* %ret to %generic*
@@ -217,40 +221,40 @@ First class functions
     %gen = alloca i32, align 4
     store i32 1, i32* %gen, align 4
     %1 = bitcast i32* %gen to %generic*
-    %clstmp = alloca { i8*, i8* }, align 8
-    %funptr14 = bitcast { i8*, i8* }* %clstmp to i8**
+    %clstmp = alloca %closure, align 8
+    %funptr14 = bitcast %closure* %clstmp to i8**
     store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__ig_ig to i8*), i8** %funptr14, align 8
-    %envptr = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %clstmp, i32 0, i32 1
-    %wrapped = alloca { i8*, i8* }, align 8
-    %funptr115 = bitcast { i8*, i8* }* %wrapped to i8**
+    %envptr = getelementptr inbounds %closure, %closure* %clstmp, i32 0, i32 1
+    %wrapped = alloca %closure, align 8
+    %funptr115 = bitcast %closure* %wrapped to i8**
     store i8* bitcast (i32 (i32)* @add1 to i8*), i8** %funptr115, align 8
-    %envptr2 = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %wrapped, i32 0, i32 1
+    %envptr2 = getelementptr inbounds %closure, %closure* %wrapped, i32 0, i32 1
     store i8* null, i8** %envptr2, align 8
-    %2 = bitcast { i8*, i8* }* %wrapped to i8*
+    %2 = bitcast %closure* %wrapped to i8*
     store i8* %2, i8** %envptr, align 8
     %ret = alloca i8, i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), align 16
     %ret3 = bitcast i8* %ret to %generic*
-    call void @apply(%generic* %ret3, %generic* %1, { i8*, i8* }* %clstmp, i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64))
+    call void @apply(%generic* %ret3, %generic* %1, %closure* %clstmp, i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64))
     %3 = bitcast %generic* %ret3 to i32*
     %realret = load i32, i32* %3, align 4
     call void @printi(i32 %realret)
     %gen4 = alloca i32, align 4
     store i32 1, i32* %gen4, align 4
     %4 = bitcast i32* %gen4 to %generic*
-    %clstmp5 = alloca { i8*, i8* }, align 8
-    %funptr616 = bitcast { i8*, i8* }* %clstmp5 to i8**
+    %clstmp5 = alloca %closure, align 8
+    %funptr616 = bitcast %closure* %clstmp5 to i8**
     store i8* bitcast (void (%generic*, %generic*, i8*, i64, i64)* @__ig_ig to i8*), i8** %funptr616, align 8
-    %envptr7 = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %clstmp5, i32 0, i32 1
-    %wrapped8 = alloca { i8*, i8* }, align 8
-    %funptr917 = bitcast { i8*, i8* }* %wrapped8 to i8**
+    %envptr7 = getelementptr inbounds %closure, %closure* %clstmp5, i32 0, i32 1
+    %wrapped8 = alloca %closure, align 8
+    %funptr917 = bitcast %closure* %wrapped8 to i8**
     store i8* bitcast (i32 (i32)* @__fun0 to i8*), i8** %funptr917, align 8
-    %envptr10 = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %wrapped8, i32 0, i32 1
+    %envptr10 = getelementptr inbounds %closure, %closure* %wrapped8, i32 0, i32 1
     store i8* null, i8** %envptr10, align 8
-    %5 = bitcast { i8*, i8* }* %wrapped8 to i8*
+    %5 = bitcast %closure* %wrapped8 to i8*
     store i8* %5, i8** %envptr7, align 8
     %ret11 = alloca i8, i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), align 16
     %ret12 = bitcast i8* %ret11 to %generic*
-    call void @apply(%generic* %ret12, %generic* %4, { i8*, i8* }* %clstmp5, i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64))
+    call void @apply(%generic* %ret12, %generic* %4, %closure* %clstmp5, i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64))
     %6 = bitcast %generic* %ret12 to i32*
     %realret13 = load i32, i32* %6, align 4
     call void @printi(i32 %realret13)
@@ -323,20 +327,22 @@ Captured values should not overwrite function params
   source_filename = "context"
   target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
   
+  %closure = type { i8*, i8* }
+  
   declare void @printi(i32 %0)
   
-  define private i32 @add({ i8*, i8* }* %a, { i8*, i8* }* %b) {
+  define private i32 @add(%closure* %a, %closure* %b) {
   entry:
-    %funcptr7 = bitcast { i8*, i8* }* %a to i8**
+    %funcptr7 = bitcast %closure* %a to i8**
     %loadtmp = load i8*, i8** %funcptr7, align 8
     %casttmp = bitcast i8* %loadtmp to i32 (i8*)*
-    %envptr = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %a, i32 0, i32 1
+    %envptr = getelementptr inbounds %closure, %closure* %a, i32 0, i32 1
     %loadtmp1 = load i8*, i8** %envptr, align 8
     %0 = call i32 %casttmp(i8* %loadtmp1)
-    %funcptr28 = bitcast { i8*, i8* }* %b to i8**
+    %funcptr28 = bitcast %closure* %b to i8**
     %loadtmp3 = load i8*, i8** %funcptr28, align 8
     %casttmp4 = bitcast i8* %loadtmp3 to i32 (i8*)*
-    %envptr5 = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %b, i32 0, i32 1
+    %envptr5 = getelementptr inbounds %closure, %closure* %b, i32 0, i32 1
     %loadtmp6 = load i8*, i8** %envptr5, align 8
     %1 = call i32 %casttmp4(i8* %loadtmp6)
     %addtmp = add i32 %0, %1
@@ -358,21 +364,21 @@ Captured values should not overwrite function params
   
   define i32 @main(i32 %0) {
   entry:
-    %two = alloca { i8*, i8* }, align 8
-    %funptr3 = bitcast { i8*, i8* }* %two to i8**
+    %two = alloca %closure, align 8
+    %funptr3 = bitcast %closure* %two to i8**
     store i8* bitcast (i32 (i8*)* @two to i8*), i8** %funptr3, align 8
     %clsr_two = alloca { i32 }, align 8
     %b4 = bitcast { i32 }* %clsr_two to i32*
     store i32 2, i32* %b4, align 4
-    %envptr = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %two, i32 0, i32 1
+    %envptr = getelementptr inbounds %closure, %closure* %two, i32 0, i32 1
     %env = bitcast { i32 }* %clsr_two to i8*
     store i8* %env, i8** %envptr, align 8
-    %clstmp = alloca { i8*, i8* }, align 8
-    %funptr15 = bitcast { i8*, i8* }* %clstmp to i8**
+    %clstmp = alloca %closure, align 8
+    %funptr15 = bitcast %closure* %clstmp to i8**
     store i8* bitcast (i32 ()* @one to i8*), i8** %funptr15, align 8
-    %envptr2 = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* %clstmp, i32 0, i32 1
+    %envptr2 = getelementptr inbounds %closure, %closure* %clstmp, i32 0, i32 1
     store i8* null, i8** %envptr2, align 8
-    %1 = call i32 @add({ i8*, i8* }* %clstmp, { i8*, i8* }* %two)
+    %1 = call i32 @add(%closure* %clstmp, %closure* %two)
     call void @printi(i32 %1)
     ret i32 0
   }

--- a/test/functions.t/shadowing.smu
+++ b/test/functions.t/shadowing.smu
@@ -1,0 +1,15 @@
+external printi : int -> unit
+
+function fib(n)
+    if n < 2 then n
+    else
+        -- local function
+        function fibn2(n)
+            fib(n - 2)
+        -- anonymous function
+        -- shadow fib. Since the function is anonymous, the inner fib call still calls the outer fib
+        fib = function (n)
+            fib(n - 1)
+        fibn2(n) + fib(n)
+
+printi(fib(30))

--- a/test/records.t/run.t
+++ b/test/records.t/run.t
@@ -71,11 +71,11 @@ Create record
     store i32 %y, i32* %y2, align 4
     %2 = bitcast { i32, i32 }* %0 to i8*
     %3 = bitcast { i32, i32 }* %1 to i8*
-    call void @llvm.memcpy.p0i8.p0i8.i64(i8* %2, i8* %3, i64 mul nuw (i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), i64 2), i1 false)
+    call void @llvm.memcpy.p0i8.p0i8.i64(i8* %2, i8* %3, i64 ptrtoint ({ i32, i32 }* getelementptr ({ i32, i32 }, { i32, i32 }* null, i32 1) to i64), i1 false)
     ret void
   }
   
-  ; Function Attrs: argmemonly nofree nosync nounwind willreturn
+  ; Function Attrs: argmemonly nofree nounwind willreturn
   declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #0
   
   define i32 @main(i32 %0) {
@@ -88,7 +88,7 @@ Create record
     ret i32 0
   }
   
-  attributes #0 = { argmemonly nofree nosync nounwind willreturn }
+  attributes #0 = { argmemonly nofree nounwind willreturn }
   unit
   8
 
@@ -107,11 +107,11 @@ Nested records
     store i32 3, i32* %z1, align 4
     %2 = bitcast { i32 }* %0 to i8*
     %3 = bitcast { i32 }* %1 to i8*
-    call void @llvm.memcpy.p0i8.p0i8.i64(i8* %2, i8* %3, i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), i1 false)
+    call void @llvm.memcpy.p0i8.p0i8.i64(i8* %2, i8* %3, i64 ptrtoint ({ i32 }* getelementptr ({ i32 }, { i32 }* null, i32 1) to i64), i1 false)
     ret void
   }
   
-  ; Function Attrs: argmemonly nofree nosync nounwind willreturn
+  ; Function Attrs: argmemonly nofree nounwind willreturn
   declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #0
   
   define i32 @main(i32 %0) {
@@ -124,7 +124,7 @@ Nested records
     call void @inner({ i32 }* %ret)
     %2 = bitcast { i32 }* %y to i8*
     %3 = bitcast { i32 }* %ret to i8*
-    call void @llvm.memcpy.p0i8.p0i8.i64(i8* %2, i8* %3, i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64), i1 false)
+    call void @llvm.memcpy.p0i8.p0i8.i64(i8* %2, i8* %3, i64 ptrtoint ({ i32 }* getelementptr ({ i32 }, { i32 }* null, i32 1) to i64), i1 false)
     %4 = getelementptr inbounds { i32, { i32 } }, { i32, { i32 } }* %1, i32 0, i32 1
     %5 = bitcast { i32 }* %4 to i32*
     %6 = load i32, i32* %5, align 4
@@ -132,6 +132,6 @@ Nested records
     ret i32 0
   }
   
-  attributes #0 = { argmemonly nofree nosync nounwind willreturn }
+  attributes #0 = { argmemonly nofree nounwind willreturn }
   unit
   3

--- a/test/typing.ml
+++ b/test/typing.ml
@@ -36,7 +36,8 @@ let test_func_1st_hint () =
 
 let test_func_1st_stay_general () =
   test "a -> (a -> b) -> b"
-    "function foo(x, f) f(x) function add1(x) x + 1 a = foo(x, add1) foo"
+    "function foo(x, f) f(x) function add1(x) x + 1 a = foo(1, add1) function \
+     boolean(x) if x then true else false b = foo(true, boolean) foo"
 
 let test_func_recursive_if () =
   test "int -> unit"

--- a/test/typing.ml
+++ b/test/typing.ml
@@ -44,6 +44,9 @@ let test_func_recursive_if () =
     "external ext : unit -> unit function foo(i) if i < 2 then ext() else \
      foo(i-1) foo"
 
+let test_func_generic_return () =
+  test "int" "function apply(f, x) f(x) function add1(x) x + 1 apply(add1, 1)"
+
 let test_record_clear () =
   test "t" "type t = { x : int, y : int } { x = 2, y = 2 }"
 
@@ -106,6 +109,7 @@ let () =
           case "1st_hint" test_func_1st_hint;
           case "1st_stay_gen" test_func_1st_stay_general;
           case "recursive_if" test_func_recursive_if;
+          case "generic_return" test_func_generic_return;
         ] );
       ( "records",
         [


### PR DESCRIPTION
Works mostly, see generic_fun_arg test.

We go down the route of boxing values instead of monomorphization. Each function with generic parameters gets a generic type argument as well, like the 'value witness tables' in swift. Only, we don't really do anything else except for copying, so it's an `i64` containing the size in our case.
The tricky part is generic 'function' parameters. For them, we create special wrapping function such that a generic `'a` can be translated to a certain type `i32` for instance.